### PR TITLE
 Add shortcuts for selection and version options in xclip

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -35,7 +35,7 @@
 #include "xclib.h"
 
 /* command line option table for XrmParseCommand() */
-XrmOptionDescRec opt_tab[17];
+XrmOptionDescRec opt_tab[19];
 int opt_tab_size;
 
 /* Options that get set on the command line */
@@ -792,7 +792,6 @@ main(int argc, char *argv[])
     /* Declare variables */
     Window win;			/* Window */
     int exit_code;
-
      /* As a convenience to command-line users, default to -o if stdin
      * is a tty. Will be overridden by -i or if user specifies a
      * filename as input.
@@ -831,6 +830,13 @@ main(int argc, char *argv[])
     opt_tab[i].value = (XPointer) NULL;
     i++;
 
+    /* selection option shortcut */
+    opt_tab[i].option = xcstrdup("-s");
+    opt_tab[i].specifier = xcstrdup(".selection");
+    opt_tab[i].argKind = XrmoptionSepArg;
+    opt_tab[i].value = (XPointer) NULL;
+    i++;
+
     /* filter option entry */
     opt_tab[i].option = xcstrdup("-filter");
     opt_tab[i].specifier = xcstrdup(".filter");
@@ -854,6 +860,13 @@ main(int argc, char *argv[])
 
     /* version option entry */
     opt_tab[i].option = xcstrdup("-version");
+    opt_tab[i].specifier = xcstrdup(".print");
+    opt_tab[i].argKind = XrmoptionNoArg;
+    opt_tab[i].value = (XPointer) xcstrdup("V");
+    i++;
+
+    /* version option shortcut*/
+    opt_tab[i].option = xcstrdup("-v");
     opt_tab[i].specifier = xcstrdup(".print");
     opt_tab[i].argKind = XrmoptionNoArg;
     opt_tab[i].value = (XPointer) xcstrdup("V");

--- a/xcprint.c
+++ b/xcprint.c
@@ -38,7 +38,7 @@ prhelp(char *name)
 "  -i, -in          read text into X selection from stdin or files [DEFAULT]\n"
 "      -filter      text piped in to selection will also be printed out\n"
 "  -o, -out         prints the selection to standard out\n"
-"      -selection   primary [DEFAULT], clipboard, secondary, or buffer-cut\n"
+"  -s, -selection   primary [DEFAULT], clipboard, secondary, or buffer-cut (p, c, s or b)\n"
 "      -target      specify target atom: image/jpeg, UTF8_STRING [DEFAULT]\n"
 "      -silent      errors only, (run in background) [DEFAULT]\n"
 "      -quiet       minimal output (foreground)\n"
@@ -50,7 +50,7 @@ prhelp(char *name)
 "      -noutf8      don't treat text as utf-8, use old unicode\n"
 "      -rmlastnl    remove the last newline character if present\n"
 "  -d, -display     X display to connect to (eg localhost:0\")\n"
-"      -version     version information\n"
+"  -v  -version     version information\n"
 "  -h, -help        this usage information\n"
 "\n" "Report bugs to <astrand@lysator.liu.se>\n", name);
     exit(EXIT_SUCCESS);


### PR DESCRIPTION
 This commit introduces two new command-line shortcuts for the xclip utility. The '-s' shortcut has been added for the '--selection'
 option, allowing users to specify the X selection (primary, clipboard, secondary, or buffer-cut) more conveniently. Additionally, the
 '-v' shortcut for '--version' has been implemented, making it easier to check the version of xclip. The help message in xcprint.c has
 been updated accordingly to reflect these new shortcuts.